### PR TITLE
Superficial fixes

### DIFF
--- a/include/myhtml/utils/mcsync.h
+++ b/include/myhtml/utils/mcsync.h
@@ -32,7 +32,7 @@ extern "C" {
     
 #include <myhtml/myosi.h>
     
-#if !defined(MyHTML_WITHOUT_THREADS)
+#if !defined(MyHTML_BUILD_WITHOUT_THREADS)
 #if defined(IS_OS_WINDOWS)
     typedef CRITICAL_SECTION pthread_mutex_t;
     typedef unsigned long pthread_mutexattr_t;
@@ -50,7 +50,7 @@ typedef mcsync_status_t;
 
 struct mcsync {
     int spinlock;
-#if !defined(MyHTML_WITHOUT_THREADS)
+#if !defined(MyHTML_BUILD_WITHOUT_THREADS)
     pthread_mutex_t *mutex;
 #endif
 }
@@ -67,7 +67,7 @@ mcsync_status_t mcsync_unlock(mcsync_t* mclock);
 mcsync_status_t mcsync_mutex_lock(mcsync_t* mclock);
 mcsync_status_t mcsync_mutex_unlock(mcsync_t* mclock);
 
-#if !defined(MyHTML_WITHOUT_THREADS) && defined(IS_OS_WINDOWS)
+#if !defined(MyHTML_BUILD_WITHOUT_THREADS) && defined(IS_OS_WINDOWS)
     static int pthread_mutex_lock(pthread_mutex_t *mutex);
     static int pthread_mutex_unlock(pthread_mutex_t *mutex);
     static int pthread_mutex_init(pthread_mutex_t *m, pthread_mutexattr_t *a);


### PR DESCRIPTION
Make header `mcsync.h` refer to `MyHTML_BUILD_WITHOUT_THREADS` like other headers do
