### PR TITLE
Fix compilation of threads on Windows

### DIFF
--- a/source/myhtml/utils/mcsync.c
+++ b/source/myhtml/utils/mcsync.c
@@ -37,33 +37,6 @@ static void mcsync_atomic_store(int* ptr, int value)
 }
 #endif
 
-#if !defined(MyHTML_BUILD_WITHOUT_THREADS) && defined(IS_OS_WINDOWS)
-static int pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-    EnterCriticalSection(mutex);
-    return 0;
-}
-
-static int pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-    LeaveCriticalSection(mutex);
-    return 0;
-}
-
-static int pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *attr)
-{
-    (void)attr;
-    InitializeCriticalSection(mutex);
-    return 0;
-}
-
-static int pthread_mutex_destroy(pthread_mutex_t *mutex)
-{
-    DeleteCriticalSection(mutex);
-    return 0;
-}
-#endif
-
 mcsync_t * mcsync_create(void)
 {
     return calloc(1, sizeof(mcsync_t));

--- a/source/myhtml/utils/mcsync.h
+++ b/source/myhtml/utils/mcsync.h
@@ -68,10 +68,30 @@ mcsync_status_t mcsync_mutex_lock(mcsync_t* mclock);
 mcsync_status_t mcsync_mutex_unlock(mcsync_t* mclock);
 
 #if !defined(MyHTML_BUILD_WITHOUT_THREADS) && defined(IS_OS_WINDOWS)
-    static int pthread_mutex_lock(pthread_mutex_t *mutex);
-    static int pthread_mutex_unlock(pthread_mutex_t *mutex);
-    static int pthread_mutex_init(pthread_mutex_t *m, pthread_mutexattr_t *a);
-    static int pthread_mutex_destroy(pthread_mutex_t *m);
+static __inline int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    EnterCriticalSection(mutex);
+    return 0;
+}
+
+static __inline int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    LeaveCriticalSection(mutex);
+    return 0;
+}
+
+static __inline int pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *a)
+{
+    (void)a;
+    InitializeCriticalSection(mutex);
+    return 0;
+}
+
+static __inline int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    DeleteCriticalSection(mutex);
+    return 0;
+}
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
The functions were declared static in the header file. This storage class implies
that the functions are local to the source file, hence the error.

Make them static inlined as they are just a call + return statement.