### PR TITLE
Fix %z format specifier on Windows

### DIFF
--- a/source/myhtml/myosi.h
+++ b/source/myhtml/myosi.h
@@ -79,6 +79,13 @@ extern "C" {
     #define myhtml_free myhtml_mem_free
 #endif
 
+/* Format */
+#ifdef IS_OS_WINDOWS
+    #define MyHTML_FMT_Z "%Iu"
+#else
+    #define MyHTML_FMT_Z "%zu"
+#endif
+
 /* Debug */
 #ifdef DEBUG_MODE
     #define MyHTML_DEBUG(format, ...)      \

--- a/source/myhtml/tag.c
+++ b/source/myhtml/tag.c
@@ -142,14 +142,14 @@ void myhtml_tag_print(myhtml_tag_t* tags, FILE* fh)
     {
         const myhtml_tag_context_t *ctx = myhtml_tag_get_by_id(tags, i);
         
-        fprintf(fh, "<%s id=\"%zu\">\n", ctx->name, i);
+        fprintf(fh, "<%s id=\"" MyHTML_FMT_Z "\">\n", ctx->name, i);
     }
     
     for(i = (MyHTML_TAG_LAST_ENTRY + 1); i < tags->tags_count; i++)
     {
         const myhtml_tag_context_t *ctx = myhtml_tag_get_by_id(tags, i);
         
-        fprintf(fh, "<%s id=\"%zu\">\n", ctx->name, i);
+        fprintf(fh, "<%s id=\"" MyHTML_FMT_Z "\">\n", ctx->name, i);
     }
 }
 

--- a/source/myhtml/token.c
+++ b/source/myhtml/token.c
@@ -879,9 +879,9 @@ void myhtml_token_print_param_by_idx(myhtml_tree_t* myhtml_tree, myhtml_token_no
         fprintf(out, "<");
     }
     
-    fprintf(out, "tag_id=%zu; body_begin=%zu; body_length=%zu; attr_first=%zu; attr_last=%zu",
+    fprintf(out, "tag_id=" MyHTML_FMT_Z "; body_begin=" MyHTML_FMT_Z "; body_length=" MyHTML_FMT_Z "; attr_first=0x%p; attr_last=0x%p",
             node->tag_id, node->raw_begin, node->raw_length,
-            (size_t)node->attr_first, (size_t)node->attr_last);
+            node->attr_first, node->attr_last);
     
     if(node->type & MyHTML_TOKEN_TYPE_CLOSE_SELF) {
         fprintf(out, " />\n");
@@ -915,7 +915,7 @@ void myhtml_token_print_by_idx(myhtml_tree_t* tree, myhtml_token_node_t* node, F
             fprintf(out, "<");
         }
         
-        fprintf(out, "%.*s tagid=\"%zu\"", (int)ctx->name_length, ctx->name, node->tag_id);
+        fprintf(out, "%.*s tagid=\"" MyHTML_FMT_Z "\"", (int)ctx->name_length, ctx->name, node->tag_id);
         
         myhtml_token_print_attr(tree, node, out);
         

--- a/source/myhtml/tree.c
+++ b/source/myhtml/tree.c
@@ -1415,7 +1415,7 @@ void myhtml_tree_active_formatting_append_with_check(myhtml_tree_t* tree, myhtml
         
 #ifdef DEBUG_MODE
         if(list[i] == NULL) {
-            MyHTML_DEBUG("Appen active formatting with check; list[%zu] is NULL", i);
+            MyHTML_DEBUG("Appen active formatting with check; list[" MyHTML_FMT_Z "] is NULL", i);
         }
 #endif
         
@@ -1484,7 +1484,7 @@ void myhtml_tree_active_formatting_up_to_last_marker(myhtml_tree_t* tree)
     
 #ifdef DEBUG_MODE
     if(list[ tree->active_formatting->length ] == NULL) {
-        MyHTML_DEBUG("Up to last marker active formatting; list[%zu] is NULL", tree->active_formatting->length);
+        MyHTML_DEBUG("Up to last marker active formatting; list[" MyHTML_FMT_Z "] is NULL", tree->active_formatting->length);
     }
 #endif
     
@@ -1494,7 +1494,7 @@ void myhtml_tree_active_formatting_up_to_last_marker(myhtml_tree_t* tree)
         
 #ifdef DEBUG_MODE
         if(list[ tree->active_formatting->length ] == NULL) {
-            MyHTML_DEBUG("Up to last marker active formatting; list[%zu] is NULL", tree->active_formatting->length);
+            MyHTML_DEBUG("Up to last marker active formatting; list[" MyHTML_FMT_Z "] is NULL", tree->active_formatting->length);
         }
 #endif
         
@@ -1517,7 +1517,7 @@ myhtml_tree_node_t * myhtml_tree_active_formatting_between_last_marker(myhtml_tr
         
 #ifdef DEBUG_MODE
         if(list[i] == NULL) {
-            MyHTML_DEBUG("Between last marker active formatting; list[%zu] is NULL", i);
+            MyHTML_DEBUG("Between last marker active formatting; list[" MyHTML_FMT_Z "] is NULL", i);
         }
 #endif
         
@@ -1556,7 +1556,7 @@ void myhtml_tree_active_formatting_reconstruction(myhtml_tree_t* tree)
         
 #ifdef DEBUG_MODE
         if(list[af_idx] == NULL) {
-            MyHTML_DEBUG("Formatting reconstruction; Step 4--6; list[%zu] is NULL", af_idx);
+            MyHTML_DEBUG("Formatting reconstruction; Step 4--6; list[" MyHTML_FMT_Z "] is NULL", af_idx);
         }
 #endif
         
@@ -1572,7 +1572,7 @@ void myhtml_tree_active_formatting_reconstruction(myhtml_tree_t* tree)
     {
 #ifdef DEBUG_MODE
         if(list[af_idx] == NULL) {
-            MyHTML_DEBUG("Formatting reconstruction; Next steps; list[%zu] is NULL", af_idx);
+            MyHTML_DEBUG("Formatting reconstruction; Next steps; list[" MyHTML_FMT_Z "] is NULL", af_idx);
         }
 #endif
         
@@ -1848,7 +1848,7 @@ bool myhtml_tree_adoption_agency_algorithm(myhtml_tree_t* tree, myhtml_token_nod
         
 #ifdef DEBUG_MODE
         if(bookmark >= tree->active_formatting->length) {
-            MyHTML_DEBUG_ERROR("Adoption agency algorithm; Before Step 18; bookmark (%zu) >= open_elements length", bookmark);
+            MyHTML_DEBUG_ERROR("Adoption agency algorithm; Before Step 18; bookmark (" MyHTML_FMT_Z ") >= open_elements length", bookmark);
         }
 #endif
         


### PR DESCRIPTION
On Windows, %I should be used instead of %z.
Also replace %zu with %p to display pointer values