### PR TITLE
chore(packages): add automatic package build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,67 @@
 language: c
+services:
+  - docker
 sudo: false
+
 compiler:
   - clang
   - gcc
+
+env:
+  matrix:
+    - OS=el DIST=6
+    - OS=el DIST=7
+    - OS=fedora DIST=24
+    - OS=fedora DIST=25
+    - OS=ubuntu DIST=precise
+    - OS=ubuntu DIST=trusty
+    - OS=ubuntu DIST=xenial
+    - OS=ubuntu DIST=yakkety
+    - OS=ubuntu DIST=zesty
+    - OS=debian DIST=wheezy
+    - OS=debian DIST=jessie
+    - OS=debian DIST=stretch
+
+matrix:
+  exclude:
+    - env: OS=el DIST=6
+      compiler: clang
+    - env: OS=el DIST=7
+      compiler: clang
+    - env: OS=fedora DIST=24
+      compiler: clang
+    - env: OS=fedora DIST=25
+      compiler: clang
+    - env: OS=ubuntu DIST=precise
+      compiler: clang
+    - env: OS=ubuntu DIST=trusty
+      compiler: clang
+    - env: OS=ubuntu DIST=xenial
+      compiler: clang
+    - env: OS=ubuntu DIST=yakkety
+      compiler: clang
+    - env: OS=debian DIST=wheezy
+      compiler: clang
+    - env: OS=debian DIST=jessie
+      compiler: clang
+    - env: OS=debian DIST=stretch
+      compiler: clang
+
 install: false
-script: make -j2 && make clean
+
+script:
+  - make -j2 && make clean
+  - if [ "$TRAVIS_BRANCH" == "master"] && [ -n "$TRAVIS_TAG" ]; then git clone https://github.com/packpack/packpack.git packpack; fi
+  - if [ "$TRAVIS_BRANCH" == "master"] && [ -n "$TRAVIS_TAG" ]; then VERSION=${TRAVIS_TAG:1} packpack/packpack; fi
+
+deploy:
+  provider     : packagecloud
+  username     : ${PACKAGECLOUD_USER}
+  repository   : ${PACKAGECLOUD_REPO}
+  token        : ${PACKAGECLOUD_TOKEN}
+  dist         : ${OS}/${DIST}
+  package_glob : build/*.{deb,rpm}
+  skip_cleanup : true
+  on           :
+    branch     : master
+    condition  : -n "${TRAVIS_TAG}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: c
-services:
-  - docker
-sudo: false
-
 compiler:
   - clang
   - gcc
 
+services:
+  - docker
+sudo: false
+
 env:
-  matrix:
-    - OS=el DIST=6
-    - OS=el DIST=7
-    - OS=fedora DIST=24
-    - OS=fedora DIST=25
-    - OS=ubuntu DIST=precise
-    - OS=ubuntu DIST=trusty
-    - OS=ubuntu DIST=xenial
-    - OS=ubuntu DIST=yakkety
-    - OS=ubuntu DIST=zesty
-    - OS=debian DIST=wheezy
-    - OS=debian DIST=jessie
-    - OS=debian DIST=stretch
+  - TARGET=test
+  - OS=el DIST=6
+  - OS=el DIST=7
+  - OS=fedora DIST=24
+  - OS=fedora DIST=25
+  - OS=ubuntu DIST=precise
+  - OS=ubuntu DIST=trusty
+  - OS=ubuntu DIST=xenial
+  - OS=ubuntu DIST=yakkety
+  - OS=debian DIST=wheezy
+  - OS=debian DIST=jessie
+  - OS=debian DIST=stretch
 
 matrix:
   exclude:
@@ -40,6 +39,8 @@ matrix:
       compiler: clang
     - env: OS=ubuntu DIST=yakkety
       compiler: clang
+    - env: OS=ubuntu DIST=zesty
+      compiler: clang
     - env: OS=debian DIST=wheezy
       compiler: clang
     - env: OS=debian DIST=jessie
@@ -50,9 +51,9 @@ matrix:
 install: false
 
 script:
-  - make -j2 && make clean
-  - if [ "$TRAVIS_BRANCH" == "master"] && [ -n "$TRAVIS_TAG" ]; then git clone https://github.com/packpack/packpack.git packpack; fi
-  - if [ "$TRAVIS_BRANCH" == "master"] && [ -n "$TRAVIS_TAG" ]; then VERSION=${TRAVIS_TAG:1} packpack/packpack; fi
+  - if [ "$TARGET" == "test" ]; then make -j2 && make clean; fi
+  - if [ -n "$TRAVIS_TAG" ] && [ -n "$OS" ]; then git clone https://github.com/packpack/packpack.git packpack; fi
+  - if [ -n "$TRAVIS_TAG" ] && [ -n "$OS" ]; then VERSION=${TRAVIS_TAG:1} packpack/packpack; fi
 
 deploy:
   provider     : packagecloud
@@ -61,7 +62,7 @@ deploy:
   token        : ${PACKAGECLOUD_TOKEN}
   dist         : ${OS}/${DIST}
   package_glob : build/*.{deb,rpm}
-  skip_cleanup : true
-  on           :
-    branch     : master
-    condition  : -n "${TRAVIS_TAG}"
+  skip_cleanup   : true
+  on             :
+    tags: true
+    condition    : -n "${OS}"

--- a/rpm/libmyhtml.spec
+++ b/rpm/libmyhtml.spec
@@ -5,7 +5,6 @@ Summary: MyHTML is a fast HTML Parser implemented as a pure C99 library.
 License: LGPLv2.1
 URL: https://github.com/lexborisov/myhtml
 Source0: https://github.com/lexborisov/myhtml/archive/%{version}/v%{version}.tar.gz
-BuildArch: noarch
 BuildRequires: make, glibc-devel
 
 %description
@@ -28,21 +27,21 @@ make shared
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p %buildroot/include
-cp -r include %buildroot/include
-make install prefix=$RPM_BUILD_ROOT
+
+mkdir -p %buildroot/%{_usr}/include
+make install prefix=$RPM_BUILD_ROOT PROJECT_INSTALL_LIBRARY=%{_usr}/%{_lib} PROJECT_INSTALL_HEADER=%{_usr}/include
 
 %files
 %defattr(-,root,root,-)
-%{_libdir}/*.so.*
-%doc LICENCE README*
-%license LICENSE
+%{_libdir}/*.so
+%doc README.md
+%{!?_licensedir:%global license %doc}
 
 %files devel
 %defattr(-,root,root,-)
-%{_includedir}/%{name}
-%doc LICENCE README*
-%license LICENSE
+%{_includedir}
+%doc README.md
+%{!?_licensedir:%global license %doc}
 
 %changelog
 * Tue Mar 21 2017 Alexander Borisov <lex.borisov@gmail.com> 4.0.0-1


### PR DESCRIPTION
### What it does?

This PR and the previous #108 add automatic package build feature to this repository using [packpack](https://github.com/packpack/packpack). It will build packages with binaries and headers for popular distros: Debian, Ubuntu, CentOS and Fedora, see `matrix` in Travis config. Built packages will be automatically uploaded to the [Packagecloud](https://packagecloud.io/), it will make the library more accesible to end-users.

### How to trigger build?

Package build will be scheduled only when you push a tag to `master` branch (see `scripts` in Travis config). So, if you want to make a new release of packages, you can simply go to the [releases ](https://github.com/lexborisov/myhtml/releases) tab and ship it :smile: 

**Keep in mind:** you need to follow the [semver](http://semver.org/) pattern there (_x.y.z_), release tag should begin from a _v_ char (_v4.0.1_).

![_892](https://user-images.githubusercontent.com/14183168/27088555-a7c5b002-5060-11e7-8150-a822d470b70e.png)

### Configuring

* register a free [Packagecloud](https://packagecloud.io/) account and create a repository
* add the following environment variables to the project settings on [Travis CI](https://github.com/packpack/packpack/blob/master/doc/travisenv.png):
  * PACKAGECLOUD_TOKEN=<token> (secret)
  * PACKAGECLOUD_USER=<username> (public)
  * PACKAGECLOUD_REPO=<reponame> (public)
* make a new release tagged with `v4.0.1`.
* PROFIT :smile: 

